### PR TITLE
Feature/controlling side effects

### DIFF
--- a/Sources/ComposableRealm/ComposableRealm.swift
+++ b/Sources/ComposableRealm/ComposableRealm.swift
@@ -4,52 +4,17 @@ import ComposableArchitecture
 import RealmSwift
 
 
-public enum RealmAction: Equatable {
-
-    case commit(RealmTransaction)
-    case saveObject(Object)
-    case deleteObject(Object)
-    case deleteObjects([Object])
-
-}
-
-
-extension RealmTransaction {
-
-    public func writeEffect(in realm: Realm) -> Effect<RealmAction, Never> {
-        .fireAndForget {
-            self.write(in: realm)
-        }
-    }
-
-}
-
 
 public extension Reducer {
 
-    /// Enhances a `Reducer` with the ability to save `Realm` objects
+    /// Enhances a `Reducer` with the ability to commit `RealmTransaction` objects
     static func realmReducer(
-        action toGlobalAction: CasePath<Action, RealmAction>,
+        action toGlobalAction: CasePath<Action, RealmTransaction>,
         realm toRealm: @escaping (Environment) -> Realm
     ) -> Reducer<State, Action, Environment> {
-        Reducer<State, RealmAction, Realm> { _, action, realm in
-            switch action {
-
-            case .commit(let transaction):
-                return transaction
-                    .writeEffect(in: realm)
-
-            case .saveObject(let object):
-                return RealmTransaction.add(object)
-                    .writeEffect(in: realm)
-
-            case .deleteObject(let object):
-                return RealmTransaction.delete(object)
-                    .writeEffect(in: realm)
-
-            case .deleteObjects(let objects):
-                return RealmTransaction.delete(objects)
-                    .writeEffect(in: realm)
+        Reducer<State, RealmTransaction, Realm> { _, transaction, realm in
+            .fireAndForget {
+                transaction.write(in: realm)
             }
         }.pullback(
             state: \.self,

--- a/Sources/RealmExtensions/RealmTransaction.swift
+++ b/Sources/RealmExtensions/RealmTransaction.swift
@@ -1,12 +1,36 @@
 import Foundation
 import RealmSwift
 
+public var SideEffects = RealmTransactionEnvironment.live()
+
+/// A way to control side effects. Handy for testing
+public struct RealmTransactionEnvironment {
+    var uuid: () -> UUID
+}
+
+extension RealmTransactionEnvironment {
+
+    internal static func live() -> Self {
+        .init(uuid: UUID.init)
+    }
+
+
+    /// Used only for testing.
+    /// Over rides UUID generationg to easily tell if `RealmTransaction` objects are equal
+    public static func mock(
+        uuid: @escaping () -> UUID = { UUID.init(uuidString: "00000000-0000-0000-0000-000000000000")! }
+    ) -> RealmTransactionEnvironment {
+        .init(uuid: uuid)
+    }
+
+}
+
 
 public struct RealmTransaction {
 
     public let transaction: (Realm) -> ()
 
-    fileprivate let uuid: UUID = UUID()
+    fileprivate let uuid: UUID = SideEffects.uuid()
 
 
     public init(transaction: @escaping (Realm) -> ()) {


### PR DESCRIPTION
This adds the ability to control side effects for `RealmTransaction` objects. We can override the `UUID` generation for snapshot tests.

I also simplified the `realmReducer` by removing the `RealmAction` enum

This is a breaking change, so I bumped the version number to 3.0.0