### PR TITLE
fixed duplicate object crash

### DIFF
--- a/Sources/RealmExtensions/RealmTransaction.swift
+++ b/Sources/RealmExtensions/RealmTransaction.swift
@@ -104,8 +104,8 @@ public struct RealmTransaction {
     
     
     public static func delete(_ object: Object) -> RealmTransaction {
-        guard !object.isInvalidated else { return .empty }
         return .init { realm in
+            guard object.realm != nil, !object.isInvalidated else { return }
             realm.chainWrite {
                 realm.delete(object)
             }
@@ -114,8 +114,9 @@ public struct RealmTransaction {
     
     
     public static func delete(_ object: Object?) -> RealmTransaction {
-        guard let object = object, !object.isInvalidated else { return .empty }
+        guard let object = object else { return .empty }
         return .init { realm in
+            guard object.realm != nil, !object.isInvalidated else { return }
             realm.chainWrite {
                 realm.delete(object)
             }
@@ -124,8 +125,8 @@ public struct RealmTransaction {
     
     
     public static func delete<S>(_ objects: S) -> RealmTransaction where S: Sequence, S.Element: Object {
-        let validObjects = objects.filter({ $0.isInvalidated == false })
-        return .init { realm in
+        .init { realm in
+            let validObjects = objects.filter({ $0.isInvalidated == false && $0.realm != nil })
             realm.chainWrite {
                 realm.delete(validObjects)
             }

--- a/Tests/RealmExtensionsTests/RealmTransactionTests.swift
+++ b/Tests/RealmExtensionsTests/RealmTransactionTests.swift
@@ -114,6 +114,23 @@ class RealmTransactionTests: RealmTestCase {
         
         XCTAssertEqual(leia.title, "general")
     }
+
+
+    // this tests insures that if an object deleted twice for some reason, an error does not occur
+    func test_multiple_duplicate_deletes() {
+        try! realm.write({
+            realm.add(luke, update: .all)
+            realm.add(han, update: .all)
+            realm.add(leia, update: .all)
+        })
+
+        let transaction = RealmTransaction.delete(luke)
+            <-> .delete(han)
+            <-> .delete(leia)
+            <-> .delete(luke)
+
+        transaction.write(in: realm)
+    }
     
 }
 


### PR DESCRIPTION
This should finally fix the crash we are seeing. I think the app is grouping a bunch of object to delete, and some of those objects are duplicated. 